### PR TITLE
export: add root password

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/passwd
+++ b/root/usr/share/nethserver-firewall-migration/passwd
@@ -1,0 +1,36 @@
+#!/usr/bin/perl
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+use strict;
+use warnings;
+use JSON;
+
+my $hash = '';
+open my $fh, '<', '/etc/shadow' or die $!;
+while( my $line = <$fh>)  {
+    if ($line =~ m/^root:([^:]+):/) {
+        $hash = $1;
+        last;
+    }
+}
+
+print(encode_json({'root' => $hash}));

--- a/ui/public/i18n/language.json
+++ b/ui/public/i18n/language.json
@@ -28,6 +28,7 @@
         "acme": "Let's Encrypt configuration",
         "reverse_proxy": "Proxy pass rules",
         "hotspot": "HotSpot (dedalo)",
+        "passwd": "Password of root user",
         "skipped": "The following configurations will not be exported",
         "skipped_network": "Network: invalid interfaces",
         "skipped_rules": "Firewall rules",


### PR DESCRIPTION
Export root password hash.

Password can be imported to avoid exposing migrated firewalls with a default weak password.


See also https://github.com/NethServer/nextsecurity/pull/65