### PR TITLE
dhcp: disable rebind protection

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/dhcp
+++ b/root/usr/share/nethserver-firewall-migration/dhcp
@@ -148,6 +148,7 @@ foreach ($hdb->get_all_by_prop('type'=>'local')) {
 }
 
 $general{'dhcpleasemax'} = $tot_limit;
+$general{'rebind_protection'} = '0';
 
 print(encode_json({
             'general' => \%general,


### PR DESCRIPTION
Preserve NS7 behavior on migration

Card: https://trello.com/c/3Ar8d8mL/127-dns-dhcp-rebind-protection-management