### PR TITLE
fix: updated name of description field

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/reverse_proxy
+++ b/root/usr/share/nethserver-firewall-migration/reverse_proxy
@@ -56,7 +56,7 @@ for ($pdb->get_all()) {
     my $config = {};
     $_->prop('Target') || next;
     my $target;
-    $config->{'ns_description'} = $_->prop('Description') || '';
+    $config->{'uci_description'} = $_->prop('Description') || '';
     my ($scheme, $host, $path, $query, $frag) = uri_split($_->prop('Target'));
     # check if host is an IP address, the regexp matches also things like 522.53.0.0
     if ($host =~ /(?<!\d)(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})(?!\d)/g) {


### PR DESCRIPTION
It seems that this is the only field where the description is actually set. Feel free to correct me if I'm wrong.

Refs: NethServer/nethsecurity#227
