### PR TITLE
firewall-migrate: drop cache before reboot

### DIFF
--- a/root/usr/sbin/firewall-migrate
+++ b/root/usr/sbin/firewall-migrate
@@ -105,6 +105,7 @@ if [ -n "$device" ]; then
     # Use 64K block to minimize write errors
     /run/zcat /run/$(basename $cimage) 2>/dev/null | /run/dd of=$device bs=1M iflag=fullblock conv=fsync status=progress
     # Try to safely reboot
+    echo 3 > /proc/sys/vm/drop_caches
     /run/sleep 1
     /run/reboot -f
     /run/sleep 5


### PR DESCRIPTION
Let's try to empty the disk buffer