### PR TITLE
Set number of leases if dhcp configured

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/dhcp
+++ b/root/usr/share/nethserver-firewall-migration/dhcp
@@ -141,15 +141,18 @@ foreach ($ddb->get_all_by_prop('type' => 'range')) {
 
 }
 
-foreach ($hdb->get_all_by_prop('type'=>'local')) {
-    $_->prop('MacAddress') || next;
-    push(@reservations, {
-        'name' => $_->key,
-        'ip' => $_->prop('IpAddress'),
-        'mac' => $_->prop('MacAddress'),
-        'ns_description' => $_->prop('Description')
-    });
-    $tot_limit++;
+if ($tot_limit > 0) {
+    foreach ($hdb->get_all_by_prop('type'=>'local')) {
+        $_->prop('MacAddress') || next;
+        push(@reservations, {
+            'name' => $_->key,
+            'ip' => $_->prop('IpAddress'),
+            'mac' => $_->prop('MacAddress'),
+            'ns_description' => $_->prop('Description')
+        });
+        $tot_limit++;
+    }
+    $general{'dhcpleasemax'} = $tot_limit;
 }
 
 $general{'dhcpleasemax'} = $tot_limit;


### PR DESCRIPTION
This pull request includes a change to the DHCP configuration. Previously, the number of leases was not being set correctly. This PR fixes that issue by ensuring that the number of leases is set when DHCP is configured.

https://github.com/NethServer/nethsecurity/issues/585