### PR TITLE
firewall-migration: fix image download URL

### DIFF
--- a/root/usr/sbin/firewall-migrate
+++ b/root/usr/sbin/firewall-migrate
@@ -30,6 +30,9 @@ image=$bdir/nethsecurity.img.gz
 uimage=${image%.gz}
 cimage=$bdir/nethsecurity-custom.img.gz
 base_url=https://updates.nethsecurity.nethserver.org/stable
+system_id=$(config getprop subscription SystemId)
+secret=$(config getprop subscription Secret)
+api_url=$(config getprop subscription ApiUrl)
 
 avail=$(df -BM --output=avail / | tail -n +2 | cut -dM -f1)
 
@@ -50,6 +53,18 @@ fi
 mkdir -p $bdir
 
 echo "Downloading image ... "
+
+if [[ -z "$secret" || -z "$system_id" ]]; then
+    release=$(curl -f -s -L -m 30 $base_url/latest_release)
+else
+    if [[ "$api_url" == *"my.nethserver.com"*  ]]; then
+        subtype="community"
+    else
+        subtype="enterprise"
+    fi
+    release=$(curl -f -s -L -m 30 "https://$system_id:$secret@distfeed.nethesis.it/repository/$subtype/nethsecurity/latest_release")
+fi
+
 release=$(curl -f -s -L -m 30 $base_url/latest_release)
 img_name="nethsecurity-$release-x86-64-generic-squashfs-combined-efi.img.gz"
 curl -s -L --connect-timeout 20 -o $image $base_url/$release/targets/x86/64/$img_name


### PR DESCRIPTION
Make sure that installations with subscription get the latest non-community stable image.
If the release of the subscription version is delayed, the community version could be ahead of the subscription one.