### PR TITLE
rules: fix blue and orange zones

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/rules
+++ b/root/usr/share/nethserver-firewall-migration/rules
@@ -57,6 +57,10 @@ sub rename_zone {
         return ['rwopenvpn', 'openvpn', 'ipsec'];
     } elsif ($zone eq 'hotsp') {
         return ['hotspot'];
+    } elsif ($zone eq 'blue') {
+        return ['guest'];
+    } elsif ($zone eq 'orange') {
+        return ['dmz'];
     }
     return [$zone];
 }


### PR DESCRIPTION
Convert blue and orange zones to the new name to avoid errors like:

  Section ns_93_udp (93_migrated_udp) option 'src' specifies invalid value 'blue'


NethServer/nethsecurity#726