### PR TITLE
openvpn: do not ignore users without 'status' prop

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/openvpn
+++ b/root/usr/share/nethserver-firewall-migration/openvpn
@@ -198,7 +198,7 @@ for ($vdb->get_all_by_prop('type', 'vpn')) {
 }
 
 for ($vdb->get_all_by_prop('type', 'vpn-user')) {
-    my $status = $_->prop('status') || next;
+    my $status = $_->prop('status') || 'enabled';
     my $secret;
     my $name = $_->key;
     $name =~ s/@.*$//;


### PR DESCRIPTION
Users migrated from NS6 to NS7 do not have the status prop. If the status prop is not present, just assume the user is enabled: this should be the same behavior of the OpenVPN authentication process.