### PR TITLE
redirects: fix VPN reflection zones

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/redirects
+++ b/root/usr/share/nethserver-firewall-migration/redirects
@@ -30,19 +30,50 @@ use NethServer::Firewall;
 my $pdb = esmith::ConfigDB->open_ro('portforward');
 my $cdb = esmith::ConfigDB->open_ro();
 my $ndb = esmith::NetworksDB->open_ro();
+my $vdb = esmith::ConfigDB->open_ro('vpn');
 my $fw = new NethServer::Firewall();
 
 my $reflection = $cdb->get_prop('firewall', 'HairpinNat') eq 'enabled' ? '1' : '0';
-my $ovpn_installed = (-f '/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/status');
-my $ovpn_status = $cdb->get_prop('openvpn@host-to-net', 'status');
+my $ovpnrw_installed = (-f '/etc/e-smith/db/configuration/defaults/openvpn@host-to-net/status');
+my $ovpnrw_status = $cdb->get_prop('openvpn@host-to-net', 'status');
+my $ovpntun_enabled = 0;
+my $ipsec_enabled = 0;
+
+foreach my $tunnel ($vdb->get_all_by_prop('type' => 'openvpn-tunnel-server')) {
+    my $status = $tunnel->prop('status') || 'disabled';
+    if ($status eq 'enabled') {
+        $ovpntun_enabled = 1;
+        last;
+    }
+}
+foreach my $tunnel ($vdb->get_all_by_prop('type' => 'tunnel')) {
+    my $status = $tunnel->prop('status') || 'disabled';
+    if ($status eq 'enabled') {
+        $ovpntun_enabled = 1;
+        last;
+    }
+}
+foreach my $tunnel ($vdb->get_all_by_prop('type' => 'ipsec-tunnel')) {
+    my $status = $tunnel->prop('status') || 'disabled';
+    if ($status eq 'enabled') {
+        $ipsec_enabled = 1;
+        last;
+    }
+}
+
 my @reflection_zones;
 if ($reflection == '1') {
     @reflection_zones = ('lan');
     if (defined($ndb->blue)) { push @reflection_zones, 'blue'; }
     if (defined($ndb->orange)) { push @reflection_zones, 'orange'; }
-    if ($ovpn_installed && $ovpn_status eq 'enabled') {
-        push(@reflection_zones, 'openvpnrw');
-        push(@reflection_zones, 'openvpntun');
+    if ($ovpnrw_installed && $ovpnrw_status eq 'enabled') {
+        push(@reflection_zones, 'rwopenvpn');
+    }
+    if ($ovpntun_enabled) {
+        push(@reflection_zones, 'openvpn');
+    }
+    if ($ipsec_enabled) {
+        push(@reflection_zones, 'ipsec');
     }
 }
 


### PR DESCRIPTION
Changes:
- fix naming of vpn zones
- add OpenVPN RW zone only if server is enabled
- add OpenVPN tunnel zone only if there is at least one tunnel enabled
- add IPsec tunnel zone only if there is at least one tunnel enabled

NethServer/nethsecurity#787