### PR TITLE
rules: ignore custom zones

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/rules
+++ b/root/usr/share/nethserver-firewall-migration/rules
@@ -62,7 +62,7 @@ sub rename_zone {
     } elsif ($zone eq 'orange') {
         return ['dmz'];
     }
-    return [$zone];
+    return ['*'];
 }
 
 


### PR DESCRIPTION
Custom zones are not created inside NS8.
As a consquence, a rule with a custom zone is ignored by fw4.

Remove the custom zone and use the any zone.

NethServer/nethsecurity#789