### PR TITLE
migrate: do not drop caches

### DIFF
--- a/root/usr/sbin/firewall-migrate
+++ b/root/usr/sbin/firewall-migrate
@@ -105,22 +105,18 @@ if [ -n "$device" ]; then
     echo "Writing the image to disk ... see you on the other side!"
     # Make sure image and bins are saved in RAM
     /bin/cp $cimage /run
-    /bin/cp /usr/bin/dd /usr/bin/zcat /usr/bin/sleep /usr/sbin/reboot /run
+    /bin/cp /usr/bin/dd /usr/bin/zcat /usr/bin/sleep /run
     # Enable sysrq
     echo 1 > /proc/sys/kernel/sysrq
     # Sync filesystems
     sync
-    echo 3 > /proc/sys/vm/drop_caches
     # Mount all filesystems in read-only
     echo u > /proc/sysrq-trigger
-    sleep 1
+    /run/sleep 1
     # Write the image
     # Use 64K block to minimize write errors
     /run/zcat /run/$(basename $cimage) 2>/dev/null | /run/dd of=$device bs=1M iflag=fullblock conv=fsync status=progress
     # Try to safely reboot
-    echo 3 > /proc/sys/vm/drop_caches
-    /run/sleep 1
-    /run/reboot -f
     /run/sleep 5
     # Reboot without sync
     echo "b" 2>/dev/null > /proc/sysrq-trigger


### PR DESCRIPTION
drop_caches reclaims RAM, but the OOM Killer will do the right job.
reboot may fail, the sysrq-trigger is safer.
