### PR TITLE
fix(network): do not use label for wans

### DIFF
--- a/root/usr/share/nethserver-firewall-migration/network
+++ b/root/usr/share/nethserver-firewall-migration/network
@@ -122,7 +122,7 @@ for my $i ($ndb->interfaces()) {
             'name' => $i->key,
             'role' => $i->prop('role'),
             'zone' => role2zone($i->prop('role')),
-            'interface' => $i->prop('nslabel') ? $i->prop('nslabel') : role2interface($i->prop('role')),
+            'interface' => role2interface($i->prop('role')),
             'ipaddr' => $i->prop('ipaddr') || '',
             'netmask' => $i->prop('netmask') || '',
             'proto' => ($i->prop('bootproto') && $i->prop('bootproto') eq 'dhcp') ? 'dhcp' : 'static'


### PR DESCRIPTION
By removing the usage of the nslabel, the following issues will be fixed:
- make sure the name of the interface does not execeed 15 chars
- avoid naming collisions when first chars 15 are the same

NethServer/nethsecurity#1067